### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ Aside from the full Rust toolchain, the following packages are required:
 
 For audio:
 
-- libportaudio19-dev
+- portaudio19-dev
 - libasound2-dev
 
 For gamepad:


### PR DESCRIPTION
At least for my ubuntu 16.04 setup, the libportaudio19-dev was impossible to find.  But if I removed the lib prefix then I could install something and get rust-oids up and running.